### PR TITLE
build: updating migration check action requirement installation to match ci.yml requirements installation

### DIFF
--- a/.github/workflows/migrations-check-mysql8.yml
+++ b/.github/workflows/migrations-check-mysql8.yml
@@ -51,8 +51,7 @@ jobs:
     # https://github.com/xmlsec/python-xmlsec/issues/314
     - name: Install Python dependencies
       run: |
-        pip install -r requirements/pip_tools.txt
-        pip install -r requirements/production.txt
+        make requirements.python
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,9 +6,9 @@
 #
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 algoliasearch==1.20.0
     # via
@@ -21,7 +21,7 @@ algoliasearch-django==1.7.3
     #   -r requirements/base.in
 amqp==5.3.1
     # via kombu
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   django
     #   django-cors-headers
@@ -43,11 +43,11 @@ beautifulsoup4==4.13.4
     #   taxonomy-connector
 billiard==4.2.1
     # via celery
-boto3==1.38.45
+boto3==1.40.14
     # via
     #   django-ses
     #   snowflake-connector-python
-botocore==1.38.45
+botocore==1.40.14
     # via
     #   boto3
     #   s3transfer
@@ -65,7 +65,7 @@ celery==5.5.3
     #   -c requirements/constraints.txt
     #   django-celery-results
     #   taxonomy-connector
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   elasticsearch
     #   requests
@@ -76,7 +76,7 @@ cffi==1.17.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   requests
     #   snowflake-connector-python
@@ -98,7 +98,7 @@ code-annotations==2.3.0
     # via edx-toggles
 contentful==2.4.0
     # via -r requirements/base.in
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   pyjwt
     #   pyopenssl
@@ -221,7 +221,7 @@ django-multi-email-field==0.8.0
     # via -r requirements/base.in
 django-multiselectfield==1.0.1
     # via -r requirements/base.in
-django-nested-admin==4.1.1
+django-nested-admin==4.1.3
     # via -r requirements/base.in
 django-nine==0.2.7
     # via django-elasticsearch-dsl-drf
@@ -261,7 +261,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==3.2.1
     # via -r requirements/base.in
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.in
     #   django-config-models
@@ -333,7 +333,7 @@ edx-rest-api-client==6.2.0
     # via
     #   -r requirements/base.in
     #   taxonomy-connector
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   edx-auth-backends
     #   edx-event-bus-kafka
@@ -351,9 +351,9 @@ elasticsearch-dsl==7.4.1
     #   -r requirements/base.in
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-fastavro==1.11.1
+fastavro==1.12.0
     # via openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via snowflake-connector-python
 frozenlist==1.7.0
     # via
@@ -363,7 +363,7 @@ getsmarter-api-clients==0.6.3
     # via -r requirements/base.in
 google-api-core==2.25.1
     # via google-api-python-client
-google-api-python-client==2.174.0
+google-api-python-client==2.179.0
     # via -r requirements/base.in
 google-auth==2.40.3
     # via
@@ -405,9 +405,9 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.in
-jsonschema==4.24.0
+jsonschema==4.25.1
     # via -r requirements/base.in
 jsonschema-specifications==2025.4.1
     # via jsonschema
@@ -415,7 +415,7 @@ kombu==5.5.4
     # via celery
 libsass==0.23.0
     # via django-libsass
-lxml[html-clean,html_clean]==6.0.0
+lxml[html-clean]==6.0.0
     # via
     #   -r requirements/base.in
     #   lxml-html-clean
@@ -428,7 +428,7 @@ markupsafe==3.0.2
     # via jinja2
 more-itertools==10.7.0
     # via simple-salesforce
-multidict==6.5.1
+multidict==6.6.4
     # via
     #   aiohttp
     #   yarl
@@ -443,7 +443,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.7.0
     # via -r requirements/base.in
-openedx-events==10.2.1
+openedx-events==10.5.0
     # via
     #   edx-event-bus-kafka
     #   edx-event-bus-redis
@@ -455,7 +455,7 @@ packaging==25.0
     #   drf-yasg
     #   kombu
     #   snowflake-connector-python
-pbr==6.1.1
+pbr==7.0.0
     # via stevedore
 pillow==9.5.0
     # via
@@ -475,7 +475,7 @@ propcache==0.3.2
     #   yarl
 proto-plus==1.26.1
     # via google-api-core
-protobuf==6.31.1
+protobuf==6.32.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -501,7 +501,7 @@ pyjwt[crypto]==2.10.1
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pymongo==4.13.2
+pymongo==4.14.1
     # via edx-opaque-keys
 pynacl==1.5.0
     # via edx-django-utils
@@ -541,7 +541,7 @@ pyyaml==6.0.2
     #   edx-django-release-util
 rcssmin==1.1.2
     # via django-compressor
-redis==6.2.0
+redis==6.4.0
     # via
     #   -r requirements/base.in
     #   walrus
@@ -549,7 +549,7 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.in
     #   algoliasearch
@@ -579,17 +579,17 @@ requests-toolbelt==0.10.1
     #   zeep
 rjsmin==1.2.2
     # via django-compressor
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   jsonschema
     #   referencing
 rsa==4.9.1
     # via google-auth
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via boto3
 semantic-version==2.10.0
     # via edx-drf-extensions
-simple-salesforce==1.12.6
+simple-salesforce==1.12.8
     # via -r requirements/base.in
 six==1.17.0
     # via
@@ -600,7 +600,7 @@ six==1.17.0
     #   edx-django-release-util
     #   elasticsearch-dsl
     #   python-dateutil
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.17.2
     # via -r requirements/base.in
 social-auth-app-django==5.4.3
     # via
@@ -621,7 +621,7 @@ stevedore==5.4.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.3.2
+taxonomy-connector==2.3.9
     # via -r requirements/base.in
 text-unidecode==1.3
     # via python-slugify
@@ -633,8 +633,9 @@ tomlkit==0.13.3
     # via snowflake-connector-python
 tqdm==4.67.1
     # via openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
+    #   aiosignal
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -652,7 +653,6 @@ uritemplate==4.2.0
     #   google-api-python-client
 urllib3==1.26.20
     # via
-    #   -c requirements/common_constraints.txt
     #   botocore
     #   elasticsearch
     #   requests
@@ -661,7 +661,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-walrus==0.9.4
+walrus==0.9.5
     # via edx-event-bus-redis
 wcwidth==0.2.13
     # via prompt-toolkit

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -19,13 +19,6 @@ Django<5.0
 # See https://github.com/openedx/edx-platform/issues/35126 for more info
 elasticsearch<7.14.0
 
-# django-simple-history>3.0.0 adds indexing and causes a lot of migrations to be affected
-
-
 # Cause: https://github.com/openedx/edx-lint/issues/458
 # This can be unpinned once https://github.com/openedx/edx-lint/issues/459 has been resolved.
 pip<24.3
-
-# Cause: https://github.com/openedx/edx-lint/issues/475
-# This can be unpinned once https://github.com/openedx/edx-lint/issues/476 has been resolved.
-urllib3<2.3.0

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -14,11 +14,11 @@ babel==2.17.0
     #   sphinx
 beautifulsoup4==4.13.4
     # via pydata-sphinx-theme
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   elasticsearch
     #   requests
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via requests
 django-elasticsearch-dsl==7.4
     # via -r requirements/docs.in
@@ -56,7 +56,7 @@ pygments==2.19.2
     #   sphinx
 python-dateutil==2.9.0.post0
     # via elasticsearch-dsl
-requests==2.32.4
+requests==2.32.5
     # via sphinx
 six==1.17.0
     # via
@@ -87,12 +87,11 @@ sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   beautifulsoup4
     #   pydata-sphinx-theme
 urllib3==1.26.20
     # via
-    #   -c requirements/common_constraints.txt
     #   elasticsearch
     #   requests

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -12,11 +12,11 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/test.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -r requirements/test.txt
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -38,7 +38,7 @@ amqp==5.3.1
     # via
     #   -r requirements/test.txt
     #   kombu
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/test.txt
     #   django
@@ -48,7 +48,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -88,12 +88,12 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.38.45
+boto3==1.40.14
     # via
     #   -r requirements/test.txt
     #   django-ses
     #   snowflake-connector-python
-botocore==1.38.45
+botocore==1.40.14
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -121,7 +121,7 @@ celery==5.5.3
     #   -r requirements/test.txt
     #   django-celery-results
     #   taxonomy-connector
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -140,7 +140,7 @@ chardet==5.2.0
     # via
     #   -r requirements/test.txt
     #   tox
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -191,11 +191,11 @@ colorama==0.4.6
     #   tox
 contentful==2.4.0
     # via -r requirements/test.txt
-coverage[toml]==7.9.1
+coverage[toml]==7.10.4
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -220,7 +220,7 @@ dill==0.4.0
     # via
     #   -r requirements/test.txt
     #   pylint
-distlib==0.3.9
+distlib==0.4.0
     # via
     #   -r requirements/test.txt
     #   virtualenv
@@ -346,7 +346,7 @@ django-multi-email-field==0.8.0
     # via -r requirements/test.txt
 django-multiselectfield==1.0.1
     # via -r requirements/test.txt
-django-nested-admin==4.1.1
+django-nested-admin==4.1.3
     # via -r requirements/test.txt
 django-nine==0.2.7
     # via
@@ -390,7 +390,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==3.2.1
     # via -r requirements/test.txt
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/test.txt
     #   django-config-models
@@ -477,7 +477,7 @@ edx-rest-api-client==6.2.0
     # via
     #   -r requirements/test.txt
     #   taxonomy-connector
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/test.txt
     #   edx-auth-backends
@@ -508,21 +508,21 @@ face==24.0.0
     #   glom
 factory-boy==3.3.3
     # via -r requirements/test.txt
-faker==37.4.0
+faker==37.5.3
     # via
     #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
     #   -r requirements/test.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/test.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-freezegun==1.5.2
+freezegun==1.5.5
     # via -r requirements/test.txt
 frozenlist==1.7.0
     # via
@@ -539,7 +539,7 @@ google-api-core==2.25.1
     # via
     #   -r requirements/test.txt
     #   google-api-python-client
-google-api-python-client==2.174.0
+google-api-python-client==2.179.0
     # via -r requirements/test.txt
 google-auth==2.40.3
     # via
@@ -615,9 +615,9 @@ jmespath==1.0.1
     #   -r requirements/test.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/test.txt
-jsonschema==4.24.0
+jsonschema==4.25.1
     # via
     #   -r requirements/test.txt
     #   semgrep
@@ -645,7 +645,7 @@ lxml-html-clean==0.4.2
     #   lxml
 markdown==3.8.2
     # via -r requirements/test.txt
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via
     #   -r requirements/test.txt
     #   rich
@@ -668,7 +668,7 @@ more-itertools==10.7.0
     # via
     #   -r requirements/test.txt
     #   simple-salesforce
-multidict==6.5.1
+multidict==6.6.4
     # via
     #   -r requirements/test.txt
     #   aiohttp
@@ -688,7 +688,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.7.0
     # via -r requirements/test.txt
-openedx-events==10.2.1
+openedx-events==10.5.0
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-kafka
@@ -716,11 +716,11 @@ packaging==25.0
     #   tox
 path==16.16.0
     # via edx-i18n-tools
-pbr==6.1.1
+pbr==7.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-peewee==3.18.1
+peewee==3.18.2
     # via
     #   -r requirements/test.txt
     #   semgrep
@@ -759,7 +759,7 @@ proto-plus==1.26.1
     # via
     #   -r requirements/test.txt
     #   google-api-core
-protobuf==6.31.1
+protobuf==6.32.0
     # via
     #   -r requirements/test.txt
     #   google-api-core
@@ -809,7 +809,7 @@ pyjwt[crypto]==2.10.1
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pylint==3.3.7
+pylint==3.3.8
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -833,7 +833,7 @@ pymemcache==4.0.0
     # via
     #   -r requirements/local.in
     #   -r requirements/test.txt
-pymongo==4.13.2
+pymongo==4.14.1
     # via
     #   -r requirements/test.txt
     #   edx-opaque-keys
@@ -873,7 +873,7 @@ pytest-responses==0.5.1
     # via -r requirements/test.txt
 pytest-split==0.10.0
     # via -r requirements/test.txt
-pytest-xdist==3.7.0
+pytest-xdist==3.8.0
     # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
@@ -924,7 +924,7 @@ rcssmin==1.1.2
     # via
     #   -r requirements/test.txt
     #   django-compressor
-redis==6.2.0
+redis==6.4.0
     # via
     #   -r requirements/test.txt
     #   walrus
@@ -933,7 +933,7 @@ referencing==0.36.2
     #   -r requirements/test.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
@@ -970,11 +970,11 @@ requests-toolbelt==0.10.1
     #   -c requirements/constraints.txt
     #   -r requirements/test.txt
     #   zeep
-responses==0.25.7
+responses==0.25.8
     # via
     #   -r requirements/test.txt
     #   pytest-responses
-rich==14.0.0
+rich==14.1.0
     # via
     #   -r requirements/test.txt
     #   semgrep
@@ -982,7 +982,7 @@ rjsmin==1.2.2
     # via
     #   -r requirements/test.txt
     #   django-compressor
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   -r requirements/test.txt
     #   jsonschema
@@ -999,7 +999,7 @@ ruamel-yaml-clib==0.2.12
     # via
     #   -r requirements/test.txt
     #   ruamel-yaml
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -1013,7 +1013,7 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 semgrep==1.52.0
     # via -r requirements/test.txt
-simple-salesforce==1.12.6
+simple-salesforce==1.12.8
     # via -r requirements/test.txt
 six==1.17.0
     # via
@@ -1037,7 +1037,7 @@ snowballstemmer==3.0.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.17.2
     # via -r requirements/test.txt
 social-auth-app-django==5.4.3
     # via
@@ -1101,9 +1101,9 @@ stevedore==5.4.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.3.2
+taxonomy-connector==2.3.9
     # via -r requirements/test.txt
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via -r requirements/test.txt
 text-unidecode==1.3
     # via
@@ -1138,10 +1138,11 @@ trio-websocket==0.12.2
     # via
     #   -r requirements/test.txt
     #   selenium
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
+    #   aiosignal
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -1165,7 +1166,6 @@ uritemplate==4.2.0
     #   google-api-python-client
 urllib3[socks]==1.26.20
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/docs.txt
     #   -r requirements/test.txt
     #   botocore
@@ -1180,11 +1180,11 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via
     #   -r requirements/test.txt
     #   tox
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/test.txt
     #   edx-event-bus-redis

--- a/requirements/pip_tools.txt
+++ b/requirements/pip_tools.txt
@@ -4,13 +4,13 @@
 #
 #    pip-compile --output-file=requirements/pip_tools.txt requirements/pip_tools.in
 #
-build==1.2.2.post1
+build==1.3.0
     # via pip-tools
 click==8.2.1
     # via pip-tools
 packaging==25.0
     # via build
-pip-tools==7.4.1
+pip-tools==7.5.0
     # via -r requirements/pip_tools.in
 pyproject-hooks==1.2.0
     # via

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -8,11 +8,11 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -r requirements/base.txt
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -30,7 +30,7 @@ amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -58,12 +58,12 @@ billiard==4.2.1
     # via
     #   -r requirements/base.txt
     #   celery
-boto3==1.38.45
+boto3==1.40.14
     # via
     #   -r requirements/base.txt
     #   django-ses
     #   snowflake-connector-python
-botocore==1.38.45
+botocore==1.40.14
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -86,7 +86,7 @@ celery==5.5.3
     #   -r requirements/base.txt
     #   django-celery-results
     #   taxonomy-connector
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
@@ -100,7 +100,7 @@ cffi==1.17.1
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -132,7 +132,7 @@ code-annotations==2.3.0
     #   edx-toggles
 contentful==2.4.0
     # via -r requirements/base.txt
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -264,7 +264,7 @@ django-multi-email-field==0.8.0
     # via -r requirements/base.txt
 django-multiselectfield==1.0.1
     # via -r requirements/base.txt
-django-nested-admin==4.1.1
+django-nested-admin==4.1.3
     # via -r requirements/base.txt
 django-nine==0.2.7
     # via
@@ -309,7 +309,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==3.2.1
     # via -r requirements/base.txt
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -385,7 +385,7 @@ edx-rest-api-client==6.2.0
     # via
     #   -r requirements/base.txt
     #   taxonomy-connector
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -404,11 +404,11 @@ elasticsearch-dsl==7.4.1
     #   -r requirements/base.txt
     #   django-elasticsearch-dsl
     #   django-elasticsearch-dsl-drf
-fastavro==1.11.1
+fastavro==1.12.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
@@ -425,7 +425,7 @@ google-api-core==2.25.1
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.174.0
+google-api-python-client==2.179.0
     # via -r requirements/base.txt
 google-auth==2.40.3
     # via
@@ -447,7 +447,7 @@ googleapis-common-protos==1.70.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
-greenlet==3.2.3
+greenlet==3.2.4
     # via gevent
 gspread==6.2.1
     # via -r requirements/base.txt
@@ -485,9 +485,9 @@ jmespath==1.0.1
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.txt
-jsonschema==4.24.0
+jsonschema==4.25.1
     # via -r requirements/base.txt
 jsonschema-specifications==2025.4.1
     # via
@@ -520,7 +520,7 @@ more-itertools==10.7.0
     # via
     #   -r requirements/base.txt
     #   simple-salesforce
-multidict==6.5.1
+multidict==6.6.4
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -540,7 +540,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.7.0
     # via -r requirements/base.txt
-openedx-events==10.2.1
+openedx-events==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -555,7 +555,7 @@ packaging==25.0
     #   gunicorn
     #   kombu
     #   snowflake-connector-python
-pbr==6.1.1
+pbr==7.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
@@ -583,7 +583,7 @@ proto-plus==1.26.1
     # via
     #   -r requirements/base.txt
     #   google-api-core
-protobuf==6.31.1
+protobuf==6.32.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -620,7 +620,7 @@ pyjwt[crypto]==2.10.1
     #   social-auth-core
 pymemcache==4.0.0
     # via -r requirements/production.in
-pymongo==4.13.2
+pymongo==4.14.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -680,7 +680,7 @@ rcssmin==1.1.2
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==6.2.0
+redis==6.4.0
     # via
     #   -r requirements/base.txt
     #   walrus
@@ -689,7 +689,7 @@ referencing==0.36.2
     #   -r requirements/base.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   algoliasearch
@@ -725,7 +725,7 @@ rjsmin==1.2.2
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -734,7 +734,7 @@ rsa==4.9.1
     # via
     #   -r requirements/base.txt
     #   google-auth
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -742,7 +742,7 @@ semantic-version==2.10.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
-simple-salesforce==1.12.6
+simple-salesforce==1.12.8
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -754,7 +754,7 @@ six==1.17.0
     #   edx-django-release-util
     #   elasticsearch-dsl
     #   python-dateutil
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.17.2
     # via -r requirements/base.txt
 social-auth-app-django==5.4.3
     # via
@@ -783,7 +783,7 @@ stevedore==5.4.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.3.2
+taxonomy-connector==2.3.9
     # via -r requirements/base.txt
 text-unidecode==1.3
     # via
@@ -802,9 +802,10 @@ tqdm==4.67.1
     # via
     #   -r requirements/base.txt
     #   openai
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/base.txt
+    #   aiosignal
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -825,7 +826,6 @@ uritemplate==4.2.0
     #   google-api-python-client
 urllib3==1.26.20
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   elasticsearch
@@ -836,7 +836,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-redis
@@ -863,7 +863,7 @@ zipp==3.23.0
     # via
     #   -r requirements/base.txt
     #   importlib-metadata
-zope-event==5.1
+zope-event==5.1.1
     # via gevent
 zope-interface==7.2
     # via gevent

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -8,11 +8,11 @@ aiohappyeyeballs==2.6.1
     # via
     #   -r requirements/base.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -r requirements/base.txt
     #   openai
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -30,7 +30,7 @@ amqp==5.3.1
     # via
     #   -r requirements/base.txt
     #   kombu
-asgiref==3.8.1
+asgiref==3.9.1
     # via
     #   -r requirements/base.txt
     #   django
@@ -40,7 +40,7 @@ asn1crypto==1.5.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
-astroid==3.3.10
+astroid==3.3.11
     # via
     #   pylint
     #   pylint-celery
@@ -71,12 +71,12 @@ boltons==21.0.0
     #   face
     #   glom
     #   semgrep
-boto3==1.38.45
+boto3==1.40.14
     # via
     #   -r requirements/base.txt
     #   django-ses
     #   snowflake-connector-python
-botocore==1.38.45
+botocore==1.40.14
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -102,7 +102,7 @@ celery==5.5.3
     #   -r requirements/base.txt
     #   django-celery-results
     #   taxonomy-connector
-certifi==2025.6.15
+certifi==2025.8.3
     # via
     #   -r requirements/base.txt
     #   elasticsearch
@@ -118,7 +118,7 @@ cffi==1.17.1
     #   snowflake-connector-python
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   -r requirements/base.txt
     #   requests
@@ -163,11 +163,11 @@ colorama==0.4.6
     #   tox
 contentful==2.4.0
     # via -r requirements/base.txt
-coverage[toml]==7.9.1
+coverage[toml]==7.10.4
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==45.0.4
+cryptography==45.0.6
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -190,7 +190,7 @@ defusedxml==0.7.1
     #   social-auth-core
 dill==0.4.0
     # via pylint
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 django==4.2.23
     # via
@@ -306,7 +306,7 @@ django-multi-email-field==0.8.0
     # via -r requirements/base.txt
 django-multiselectfield==1.0.1
     # via -r requirements/base.txt
-django-nested-admin==4.1.1
+django-nested-admin==4.1.3
     # via -r requirements/base.txt
 django-nine==0.2.7
     # via
@@ -350,7 +350,7 @@ django-waffle==5.0.0
     #   edx-toggles
 django-webpack-loader==3.2.1
     # via -r requirements/base.txt
-djangorestframework==3.16.0
+djangorestframework==3.16.1
     # via
     #   -r requirements/base.txt
     #   django-config-models
@@ -430,7 +430,7 @@ edx-rest-api-client==6.2.0
     # via
     #   -r requirements/base.txt
     #   taxonomy-connector
-edx-toggles==5.3.0
+edx-toggles==5.4.1
     # via
     #   -r requirements/base.txt
     #   edx-auth-backends
@@ -455,19 +455,19 @@ face==24.0.0
     # via glom
 factory-boy==3.3.3
     # via -r requirements/test.in
-faker==37.4.0
+faker==37.5.3
     # via factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
     #   -r requirements/base.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   -r requirements/base.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-freezegun==1.5.2
+freezegun==1.5.5
     # via -r requirements/test.in
 frozenlist==1.7.0
     # via
@@ -482,7 +482,7 @@ google-api-core==2.25.1
     # via
     #   -r requirements/base.txt
     #   google-api-python-client
-google-api-python-client==2.174.0
+google-api-python-client==2.179.0
     # via -r requirements/base.txt
 google-auth==2.40.3
     # via
@@ -547,9 +547,9 @@ jmespath==1.0.1
     #   -r requirements/base.txt
     #   boto3
     #   botocore
-jsonfield==3.1.0
+jsonfield==3.2.0
     # via -r requirements/base.txt
-jsonschema==4.24.0
+jsonschema==4.25.1
     # via
     #   -r requirements/base.txt
     #   semgrep
@@ -576,7 +576,7 @@ lxml-html-clean==0.4.2
     #   lxml
 markdown==3.8.2
     # via -r requirements/base.txt
-markdown-it-py==3.0.0
+markdown-it-py==4.0.0
     # via rich
 markupsafe==3.0.2
     # via
@@ -592,7 +592,7 @@ more-itertools==10.7.0
     # via
     #   -r requirements/base.txt
     #   simple-salesforce
-multidict==6.5.1
+multidict==6.6.4
     # via
     #   -r requirements/base.txt
     #   aiohttp
@@ -612,7 +612,7 @@ openai==0.28.1
     #   taxonomy-connector
 openedx-atlas==0.7.0
     # via -r requirements/base.txt
-openedx-events==10.2.1
+openedx-events==10.5.0
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-kafka
@@ -634,11 +634,11 @@ packaging==25.0
     #   semgrep
     #   snowflake-connector-python
     #   tox
-pbr==6.1.1
+pbr==7.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-peewee==3.18.1
+peewee==3.18.2
     # via semgrep
 pillow==9.5.0
     # via
@@ -672,7 +672,7 @@ proto-plus==1.26.1
     # via
     #   -r requirements/base.txt
     #   google-api-core
-protobuf==6.31.1
+protobuf==6.32.0
     # via
     #   -r requirements/base.txt
     #   google-api-core
@@ -713,7 +713,7 @@ pyjwt[crypto]==2.10.1
     #   simple-salesforce
     #   snowflake-connector-python
     #   social-auth-core
-pylint==3.3.7
+pylint==3.3.8
     # via
     #   edx-lint
     #   pylint-celery
@@ -729,7 +729,7 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pymemcache==4.0.0
     # via -r requirements/test.in
-pymongo==4.13.2
+pymongo==4.14.1
     # via
     #   -r requirements/base.txt
     #   edx-opaque-keys
@@ -765,7 +765,7 @@ pytest-responses==0.5.1
     # via -r requirements/test.in
 pytest-split==0.10.0
     # via -r requirements/test.in
-pytest-xdist==3.7.0
+pytest-xdist==3.8.0
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
@@ -812,7 +812,7 @@ rcssmin==1.1.2
     # via
     #   -r requirements/base.txt
     #   django-compressor
-redis==6.2.0
+redis==6.4.0
     # via
     #   -r requirements/base.txt
     #   walrus
@@ -821,7 +821,7 @@ referencing==0.36.2
     #   -r requirements/base.txt
     #   jsonschema
     #   jsonschema-specifications
-requests==2.32.4
+requests==2.32.5
     # via
     #   -r requirements/base.txt
     #   algoliasearch
@@ -856,17 +856,17 @@ requests-toolbelt==0.10.1
     #   -c requirements/constraints.txt
     #   -r requirements/base.txt
     #   zeep
-responses==0.25.7
+responses==0.25.8
     # via
     #   -r requirements/test.in
     #   pytest-responses
-rich==14.0.0
+rich==14.1.0
     # via semgrep
 rjsmin==1.2.2
     # via
     #   -r requirements/base.txt
     #   django-compressor
-rpds-py==0.25.1
+rpds-py==0.27.0
     # via
     #   -r requirements/base.txt
     #   jsonschema
@@ -879,7 +879,7 @@ ruamel-yaml==0.17.40
     # via semgrep
 ruamel-yaml-clib==0.2.12
     # via ruamel-yaml
-s3transfer==0.13.0
+s3transfer==0.13.1
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -893,7 +893,7 @@ semantic-version==2.10.0
     #   edx-drf-extensions
 semgrep==1.52.0
     # via -r requirements/test.in
-simple-salesforce==1.12.6
+simple-salesforce==1.12.8
     # via -r requirements/base.txt
 six==1.17.0
     # via
@@ -910,7 +910,7 @@ slumber==0.7.1
     # via -r requirements/test.in
 sniffio==1.3.1
     # via trio
-snowflake-connector-python==3.15.0
+snowflake-connector-python==3.17.2
     # via -r requirements/base.txt
 social-auth-app-django==5.4.3
     # via
@@ -940,9 +940,9 @@ stevedore==5.4.1
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
-taxonomy-connector==2.3.2
+taxonomy-connector==2.3.9
     # via -r requirements/base.txt
-testfixtures==8.3.0
+testfixtures==9.1.0
     # via -r requirements/test.in
 text-unidecode==1.3
     # via
@@ -972,9 +972,10 @@ trio==0.30.0
     #   trio-websocket
 trio-websocket==0.12.2
     # via selenium
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -r requirements/base.txt
+    #   aiosignal
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -997,7 +998,6 @@ uritemplate==4.2.0
     #   google-api-python-client
 urllib3[socks]==1.26.20
     # via
-    #   -c requirements/common_constraints.txt
     #   -r requirements/base.txt
     #   botocore
     #   elasticsearch
@@ -1011,9 +1011,9 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.31.2
+virtualenv==20.34.0
     # via tox
-walrus==0.9.4
+walrus==0.9.5
     # via
     #   -r requirements/base.txt
     #   edx-event-bus-redis


### PR DESCRIPTION
- Updates migration check action requirement installation to match ci.yml requirements installation to fix the migration check failure
  -  Unsure why it is failing in first place. Most likely, it is OS dependency flow in that particular action as the flow does not fail on my local Mac or even in ci.yml
- Run make upgrade to update requirement files

Migration checks were failing with the following error (https://github.com/openedx/course-discovery/actions/runs/17066352522/job/48384347446?pr=4659) :

```
Collecting cairocffi==1.4.0 (from -r requirements/production.txt (line 76))
  Downloading cairocffi-1.4.0.tar.gz (69 kB)
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [92 lines of output]
      /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
      !!
      
              ********************************************************************************
              Please consider removing the following classifiers in favor of a SPDX license expression:
      
              License :: OSI Approved :: BSD License
      
              See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
              ********************************************************************************
      
      !!
        self._finalize_license_expression()
      /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py:483: SetuptoolsDeprecationWarning: Please provide a valid glob pattern.
      !!
      
              ********************************************************************************
              Pattern '[ LICENSE ]' contains invalid characters.
      
              By 2026-Mar-20, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
      
              See https://packaging.python.org/en/latest/specifications/glob-patterns/ for details.
              ********************************************************************************
      
      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py:483: SetuptoolsDeprecationWarning: Cannot find any files for the given pattern.
      !!
      
              ********************************************************************************
              Pattern '[ LICENSE ]' did not match any files.
      
              By 2026-Mar-20, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
      
      !!
        for path in sorted(cls._find_pattern(pattern, enforce_match))
      /opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/__init__.py:92: _DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.
      !!
      
              ********************************************************************************
              Requirements should be satisfied by a PEP 517 installer.
              If you are using pip, you can try `pip install --use-pep517`.
      
              By 2025-Oct-31, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.
              ********************************************************************************
      
      !!
        dist.fetch_build_eggs(dist.setup_requires)
      Traceback (most recent call last):
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/cparser.py", line 5, in <module>
          from . import _pycparser as pycparser
      ImportError: cannot import name '_pycparser' from 'cffi' (/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/__init__.py)
      
      During handling of the above exception, another exception occurred:
      
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 35, in <module>
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/setup.py", line 10, in <module>
          setup(
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/__init__.py", line 115, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 148, in setup
          _setup_distribution = dist = klass(attrs)
                                       ^^^^^^^^^^^^
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py", line 321, in __init__
          _Distribution.__init__(self, dist_attrs)
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 309, in __init__
          self.finalize_options()
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py", line 784, in finalize_options
          ep(self)
        File "/opt/hostedtoolcache/Python/3.12.11/x64/lib/python3.12/site-packages/setuptools/dist.py", line 804, in _finalize_setup_keywords
          ep.load()(self, ep.name, value)
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/setuptools_ext.py", line 216, in cffi_modules
          add_cffi_module(dist, cffi_module)
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/setuptools_ext.py", line 49, in add_cffi_module
          execfile(build_file_name, mod_vars)
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/setuptools_ext.py", line 25, in execfile
          exec(code, glob, glob)
        File "cairocffi/ffi_build.py", line 28, in <module>
          ffi = FFI()
                ^^^^^
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/api.py", line 65, in __init__
          from . import cparser
        File "/tmp/pip-install-zotjirau/cairocffi_0f5d3037b6aa4c768aa1222f2a0ad209/.eggs/cffi-1.17.1-py3.12-linux-x86_64.egg/cffi/cparser.py", line 7, in <module>
          import pycparser
      ModuleNotFoundError: No module named 'pycparser'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

```